### PR TITLE
Decluttered header

### DIFF
--- a/app/bulk_resource/views.py
+++ b/app/bulk_resource/views.py
@@ -7,7 +7,7 @@ from forms import UploadForm
 
 @bulk_resource.route('/upload', methods=['GET', 'POST'])
 @login_required
-def upload():
+def index():
     """Upload new resources in bulk with CSV file."""
     form = UploadForm()
     if form.validate_on_submit():

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -7,8 +7,7 @@ from .. import db, login_manager
 
 
 class Permission:
-    GENERAL = 0x01
-    ADMINISTER = 0xff
+    ADMINISTER = 0x01
 
 
 class Role(db.Model):

--- a/app/templates/admin/index.html
+++ b/app/templates/admin/index.html
@@ -24,8 +24,11 @@
     <div class="ui stackable centered grid container">
         <div class="twelve wide column">
             <h2 class="ui header">
-                Admin Dashboard
+                Administrator Dashboard
             </h2>
+            <h3 class="ui header">
+                Manage Users
+            </h3>
             <div class="ui two column stackable grid">
                 {{ dashboard_option('Registered Users', 'admin.registered_users',
                                     description='View and manage user accounts', icon='users icon') }}
@@ -34,6 +37,27 @@
                 {{ dashboard_option('Invite New User', 'admin.invite_user',
                                     description='Invites a new user to create their own account', icon='add user icon') }}
             </div>
+            <h3 class="ui header">
+                Manage Resources
+            </h3>
+            <div class="ui two column stackable grid">
+                {{ dashboard_option('All Resources', 'single_resource.index',
+                                    description='View, edit, and delete existing resources', icon='book icon') }}
+                {{ dashboard_option('Suggested Resources', 'suggestion.index',
+                                    description='Review suggested resources', icon='checkmark box icon') }}
+                {{ dashboard_option('Individual Upload', 'single_resource.index',
+                                    description='Create a single new resource', icon='cube icon') }}
+                {{ dashboard_option('Bulk Upload', 'bulk_resource.index',
+                                    description='Upload a batch of new resources', icon='cubes icon') }}
+                {{ dashboard_option('Manage Descriptors', 'descriptor.index',
+                                    description='Manage global resource descriptors', icon='tags icon') }}
+                {{ dashboard_option('Download Resources', 'single_resource.index',
+                                    description='Download snapshot of all current resources', icon='download icon') }}
+
+            </div>
+            <h3 class="ui header">
+                Manage Static Pages
+            </h3>
         </div>
     </div>
 {% endblock %}

--- a/app/templates/macros/nav_macros.html
+++ b/app/templates/macros/nav_macros.html
@@ -19,10 +19,6 @@
 
 {% macro account_items(current_user) %}
     {% if current_user.is_authenticated() %}
-        <a href="{{ url_for('descriptor.index') }}" class="item">Descriptors</a>
-        <a href="{{ url_for('single_resource.index') }}" class="item">Single Resource</a>
-        <a href="{{ url_for('bulk_resource.review') }}" class="item">Resources in Bulk</a>
-        <a href="{{ url_for('suggestion.index') }}" class="item">Suggestions</a>
         <a href="{{ url_for('account.manage') }}" class="item">Your Account</a>
         <a href="{{ url_for('account.logout') }}" class="item">Log out</a>
     {% else %}


### PR DESCRIPTION
It seemed a bit weird that we had an "Administrator Dashboard" and also a bunch of admin features in the nav bar. I moved all of our features into a "Manage Resources" section of the Admin Dashboard, thus decluttering the nav bar. This reorganization also leaves space for (future) static page links in the nav bar.

<img width="1199" alt="screen shot 2016-03-25 at 10 02 32 pm" src="https://cloud.githubusercontent.com/assets/3880084/14057419/4f05e480-f2d5-11e5-85e7-a3c5b76291b4.png">
