### PR TITLE
Bundle jquery at top for use in other js files

### DIFF
--- a/app/assets.py
+++ b/app/assets.py
@@ -22,9 +22,9 @@ vendor_css = Bundle(
 )
 
 vendor_js = Bundle(
+    'vendor/jquery.min.js',
     'vendor/async.js',
     'vendor/address-autocomplete.js',
-    'vendor/jquery.min.js',
     'vendor/papaparse.min.js',
     'vendor/semantic.min.js',
     'vendor/tablesort.min.js',


### PR DESCRIPTION
`address-autocomplete.js` was using jquery functions but was bundled above jquery, causing errors