### PR TITLE
Styling for About and Contact

### DIFF
--- a/app/assets/styles/admin.scss
+++ b/app/assets/styles/admin.scss
@@ -1,15 +1,15 @@
 // About page 
 .updated_alert, .ui.button.cancel-edit, .ui.button.end-edit {
-	display: none;
+  display: none;
 }
 
 .cke_editable {
-	padding: .5em;
+  padding: .5em;
 }
 
 #editor-about, #editor-contact {
-	max-height: 300px;
-	min-height: 100px;
-	overflow-y: scroll;
-	word-wrap: break-word;
+  max-height: 300px;
+  min-height: 100px;
+  overflow-y: scroll;
+  word-wrap: break-word;
 }

--- a/app/assets/styles/admin.scss
+++ b/app/assets/styles/admin.scss
@@ -1,0 +1,15 @@
+// About page 
+.updated_alert, .ui.button.cancel-edit, .ui.button.end-edit {
+	display: none;
+}
+
+.cke_editable {
+	padding: .5em;
+}
+
+#editor-about, #editor-contact {
+	max-height: 300px;
+	min-height: 100px;
+	overflow-y: scroll;
+	word-wrap: break-word;
+}

--- a/app/static/styles/app.css
+++ b/app/static/styles/app.css
@@ -1,3 +1,21 @@
+@media -sass-debug-info{filename{}line{font-family:\000032}}
+.updated_alert, .ui.button.cancel-edit, .ui.button.end-edit {
+  display: none;
+}
+
+@media -sass-debug-info{filename{}line{font-family:\000036}}
+.cke_editable {
+  padding: .5em;
+}
+
+@media -sass-debug-info{filename{}line{font-family:\0000310}}
+#editor-about, #editor-contact {
+  max-height: 300px;
+  min-height: 100px;
+  overflow-y: scroll;
+  word-wrap: break-word;
+}
+
 @media -sass-debug-info{filename{}line{font-family:\000037}}
 nav {
   margin-bottom: 40px !important;

--- a/app/templates/macros/page_macros.html
+++ b/app/templates/macros/page_macros.html
@@ -1,6 +1,8 @@
 {% macro render_inline_editor(editable_html_obj, current_user) %}
-    <div id="editor-{{ editable_html_obj.editor_name }}" contenteditable="false">
-        {{ editable_html_obj.value|safe }}
+    <div class="ui segment">
+        <div id="editor-{{ editable_html_obj.editor_name }}" contenteditable="false">
+            {{ editable_html_obj.value|safe }}
+        </div>
     </div>
 
     {% if current_user.is_admin() %}
@@ -20,11 +22,6 @@
     var editorIDName = "editor-{{ editable_html_obj.editor_name }}";
     var original_data;
     $(document).ready(function() {
-        {% if current_user.is_admin() %}
-            $(".end-edit").hide();
-            $(".cancel-edit").hide();
-            $(".updated_alert").hide();
-        {% endif %}
         $(".start-edit").click(function() {
             CKEDITOR.disableAutoInline = true;
             var editor = CKEDITOR.inline(editorIDName, {
@@ -33,6 +30,7 @@
             });
             original_data = CKEDITOR.instances[editorIDName].getData();
             $(".start-edit").hide();
+            $(".updated_alert").hide();
             $(".end-edit").show();
             $(".cancel-edit").show();
             $("#" + editorIDName).attr("contenteditable","true");
@@ -53,8 +51,9 @@
             $(".updated_alert").show();
             $("#" + editorIDName).attr("contenteditable","false");
         });
-        $(".cancel-edit").click(function() {
-            if ( CKEDITOR.instances[editorIDName] ) {
+
+        function cancelEdit(){
+          if ( CKEDITOR.instances[editorIDName] ) {
                 if ( original_data !== null) {
                     CKEDITOR.instances[editorIDName].setData(original_data);
                 }
@@ -64,6 +63,15 @@
             $(".end-edit").hide();
             $(".start-edit").show();
             $(".updated_alert").hide();
+            $("#" + editorIDName).attr("contenteditable","false");
+        }
+
+        $(".cancel-edit").click(function() {
+            cancelEdit();
+        });
+
+        $("#" + editorIDName).focusout(function() {
+            cancelEdit();
         });
     });
     </script>

--- a/app/templates/main/about.html
+++ b/app/templates/main/about.html
@@ -3,7 +3,10 @@
 
 {% block content %}
     <div class="ui text container">
-        <h1>About</h1>
+        <h1 class="ui header">
+        	About
+        	<div class="sub header">This is what the user will see on the About page</div>
+        </h1>
         {{ page.render_inline_editor(editable_html_obj, current_user) }}
     </div>
 

--- a/app/templates/main/contact.html
+++ b/app/templates/main/contact.html
@@ -3,7 +3,10 @@
 
 {% block content %}
     <div class="ui text container">
-        <h1>Contact Us</h1>
+        <h1 class="ui header">
+        	Contact Us
+        	<div class="sub header">This is what the user will see on the Contact page</div>
+        </h1>
         {{ page.render_inline_editor(editable_html_obj, current_user) }}
     </div>
 


### PR DESCRIPTION
Allowed you to exit out of the editor when you click outside of the editor box. Styling on the box fixed padding,margins and other things. Added a description that the user will see right under the header for about and contact us pages. 