### PR TITLE
Remove js imports

### DIFF
--- a/app/templates/descriptor/index.html
+++ b/app/templates/descriptor/index.html
@@ -1,9 +1,5 @@
 {% extends 'layouts/base.html' %}
 
-{% block javascript %}
-    {% assets 'descriptor_js' %}<script type="text/javascript" src="{{ ASSET_URL }}"></script>{% endassets %}
-{% endblock %}
-
 {% block content %}
     <div class="ui stackable grid container">
         <div class="sixteen wide tablet twelve wide computer centered column">

--- a/app/templates/single_resource/index.html
+++ b/app/templates/single_resource/index.html
@@ -1,9 +1,5 @@
 {% extends 'layouts/base.html' %}
 
-{% block javascript %}
-    {% assets 'resources_js' %}<script type="text/javascript" src="{{ ASSET_URL }}"></script>{% endassets %}
-{% endblock %}
-
 {% block content %}
     <div class="ui stackable grid container">
         <div class="sixteen wide tablet twelve wide computer centered column">
@@ -25,7 +21,7 @@
                 </div>
             </div>
         </div>-->
-        
+
             <!--waiting for functionality-->
             <div class="ui right action left icon input menu">
                 <i class="search icon"></i>


### PR DESCRIPTION
All js files are compiled to `app.js` which is imported in the head so no need for specific js file imports