### PR TITLE
Fix comment on about/contact editor

### DIFF
--- a/app/templates/macros/page_macros.html
+++ b/app/templates/macros/page_macros.html
@@ -34,8 +34,8 @@
 
             //Disables the automatic blur function of ckeditor.
             editor.on('blur', function(e) {
-                return false;    
-            }); '''Disables the automatic blur function of ckeditor'''
+                return false;
+            });
             original_data = CKEDITOR.instances[editorIDName].getData();
             $(".start-edit").hide();
             $(".end-edit").show();


### PR DESCRIPTION
@OBrandon Accidentally missed this in your PR - you added the comment as a string in the function which created errors