### PR TITLE
Don't show text descriptor if empty

### DIFF
--- a/app/templates/main/index.html
+++ b/app/templates/main/index.html
@@ -185,10 +185,12 @@
     <h2 class="ui dividing header">Information</h2>
     <div class="ui list">
       {% raw %}{{#each descriptors}}{% endraw %}
-      <div class="item descriptor">
-        <div class="header">{% raw %}{{ key }}{% endraw %}</div>
-        {% raw %}{{ value }}{% endraw %}
-      </div>
+        {% raw %}{{#if value}}{% endraw %}
+          <div class="item descriptor">
+            <div class="header">{% raw %}{{ key }}{% endraw %}</div>
+            {% raw %}{{ value }}{% endraw %}
+          </div>
+        {% raw %}{{/if}}{% endraw %}
       {% raw %}{{/each}}{% endraw %}
     </div>
   </div>
@@ -196,7 +198,7 @@
   <div class="actions">
     <h2 class="ui dividing header">Actions</h2>
     <div class="userRating" id="user-rating">
-      <div class="ui form"> 
+      <div class="ui form">
         <h3 class="ui header">Submit a Review</h3>
         <div class="field">
           <label>Rating (Required)</label>


### PR DESCRIPTION
On detailed resource view page, don't show a text descriptor if it is empty