### PR TITLE
Reset scroll on detailed resource view

### DIFF
--- a/app/assets/scripts/map.js
+++ b/app/assets/scripts/map.js
@@ -73,6 +73,7 @@ function displayDetailedResourceView(marker) {
 
     // Set handlers and populate DOM elements from resource template
     // Can only reference elements in template after compilation
+    $("#resource-info").scrollTop(0); // reset scroll on div to top
     $('#back-button').click(function() {
       $("#map").show();
       $("#resource-info").hide();
@@ -124,8 +125,8 @@ function submitReview(rating, review, id){
      contentType: 'application/json',
      dataType: 'json',
      method: 'POST'
-  }); 
-  $(".userRating").hide();   
+  });
+  $(".userRating").hide();
   $(".successMessage").show();
 }
 


### PR DESCRIPTION
Since we reuse the same detailed resource view div, if we scrolled on the previous time we displayed it, and we click another resource, we still get that same level of scroll but we want to display the div always starting from the top