### PR TITLE
Mobile responsive map/list grid view

### DIFF
--- a/app/assets/scripts/app.js
+++ b/app/assets/scripts/app.js
@@ -3,7 +3,8 @@ var mobileBreakpoint = 768;
 var tabletBreakpoint = 992;
 var smallMonitorBreakpoint = 1200;
 
-var singleColBreakpoint = 900;
+var singleColNoSpaceBreakpoint = 500;
+var singleColBreakpoint = 800;
 var twoColResizeBreakpoint = 1150;
 
 $(document).ready(function () {

--- a/app/assets/scripts/app.js
+++ b/app/assets/scripts/app.js
@@ -1,7 +1,10 @@
 // Semantic UI breakpoints
-var mobileBreakpoint = '768px';
-var tabletBreakpoint = '992px';
-var smallMonitorBreakpoint = '1200px';
+var mobileBreakpoint = 768;
+var tabletBreakpoint = 992;
+var smallMonitorBreakpoint = 1200;
+
+var singleColBreakpoint = 900;
+var twoColResizeBreakpoint = 1150;
 
 $(document).ready(function () {
 

--- a/app/assets/scripts/map.js
+++ b/app/assets/scripts/map.js
@@ -274,6 +274,11 @@ function initLocationSearch(map) {
 
     infowindow.setContent(locationMarkerInfo);
     infowindow.open(map, locationMarker);
+
+    // If in single column view, entering a location should go to the map view
+    if ($(window).width() <= singleColBreakpoint) {
+      listToMapSingleColumn();
+    }
   });
 
   // Delete location marker when deleting location query

--- a/app/assets/scripts/map.js
+++ b/app/assets/scripts/map.js
@@ -9,6 +9,7 @@ var markers = [];
 var infowindow;
 var focusZoom = 17;
 var locationMarker;
+var allResourceBounds;
 
 // Click listener for a marker.
 function markerListener(marker, event) {
@@ -349,6 +350,7 @@ function populateMarkers(resources) {
 
   map.fitBounds(bounds);
   map.setCenter(bounds.getCenter());
+  allResourceBounds = bounds;
 }
 
 /*
@@ -474,7 +476,6 @@ function makeResponsive() {
   } else if ($(window).width() > twoColResizeBreakpoint) {
     $('#left-column').removeClass().addClass('four wide column');
     $('#right-column').removeClass().addClass('twelve wide column');
-    doubleColumnResets();
   }
 }
 
@@ -483,8 +484,13 @@ function makeResponsive() {
 function singleColumnResets() {
   $('#left-column').removeClass().addClass('sixteen wide column');
   $('#right-column').removeClass().addClass('sixteen wide column');
-  $('#right-column').hide();
-  setNavSwitching();
+
+  // switched from double to single
+  // don't want to hide if a resize within single view is triggered
+  if ($('#right-column').is(':visible') && $('#left-column').is(':visible')) {
+    $('#right-column').hide();
+    setNavSwitching();
+  }
 }
 
 // Set a nav element that allows toggling between list and map view
@@ -510,11 +516,18 @@ function listToMapSingleColumn() {
   $('#left-column').hide();
   $('#right-column').show();
   $('#map').show();
+  $('#map-footer').hide();
+  $('#map').height($('#right-column').height());
+
+  // show all resources on map
+  if (allResourceBounds) {
+    map.fitBounds(allResourceBounds);
+    map.setCenter(allResourceBounds.getCenter());
+  }
   var center = map.getCenter();
   // Need to call resize event on map or creates dead grey area on map
   google.maps.event.trigger(map, "resize");
   map.setCenter(center);
-  map.setZoom(14);
 
   $('#nav-to-list').show();
   $('#nav-to-map').hide();
@@ -539,9 +552,13 @@ function doubleColumnResets() {
   $('#right-column').show();
   $('.nav-mobile-switch').hide();
 
+  // show all resources on map
+  if (allResourceBounds) {
+    map.fitBounds(allResourceBounds);
+    map.setCenter(allResourceBounds.getCenter());
+  }
   var center = map.getCenter();
   // Need to call resize event on map or creates dead grey area on map
   google.maps.event.trigger(map, "resize");
   map.setCenter(center);
-  map.setZoom(14);
 }

--- a/app/assets/scripts/map.js
+++ b/app/assets/scripts/map.js
@@ -12,6 +12,14 @@ var locationMarker;
 
 // Click listener for a marker.
 function markerListener(marker, event) {
+  // mobile responsive
+  if ($(window).width() <= singleColBreakpoint) {
+    $('#left-column').hide();
+    $('#right-column').show();
+    resizeMapListGrid();
+    map.setZoom(17);
+  }
+
   $("#map").show();
   $("#resource-info").hide();
 
@@ -29,11 +37,17 @@ function markerListener(marker, event) {
   if (infowindow) {
     infowindow.close();
   }
-  infowindow = new google.maps.InfoWindow({
-    content: markerInfo,
-    maxWidth: 300,
-  });
-  infowindow.open(map, marker);
+
+  // If more than one column, display info window
+  if ($(window).width() > singleColBreakpoint) {
+    infowindow = new google.maps.InfoWindow({
+      content: markerInfo,
+      maxWidth: 300,
+    });
+    infowindow.open(map, marker);
+  } else { // One column then display bottom box for info
+
+  }
 
   // Marker "more information" link to detailed resource information view
   $(".more-info").click(function() {
@@ -177,6 +191,10 @@ function initMap() {
   google.maps.event.addListenerOnce(map, 'idle', function() {
     populateListDiv();
   });
+
+  if ($(window).width() <= singleColBreakpoint) {
+    $('#right-column').hide();
+  }
 }
 
 /*
@@ -369,11 +387,34 @@ function populateListDiv() {
 // Resize map/list area - set height to fit screen
 function resizeMapListGrid() {
   var navHeight = $('.ui.navigation.grid').height();
-  // TODO: remove hack of subtracting 40
+
+  // TODO: remove hack of subtracting 40 and 60
   $('#map-list-grid').height($('body').height() - navHeight - 40);
 
   var center = map.getCenter();
   // Need to call resize event on map or creates dead grey area on map
   google.maps.event.trigger(map, "resize");
   map.setCenter(center);
+}
+
+function makeResponsive() {
+  // Change to a single column view
+  if ($(window).width() <= singleColBreakpoint) {
+    $('#left-column').removeClass().addClass('sixteen wide column');
+    $('#right-column').removeClass().addClass('sixteen wide column');
+    $('#map-list-grid').addClass('grid-space');
+  } else if ( // Change to double column views
+    $(window).width() > singleColBreakpoint
+    && $(window).width() <= twoColResizeBreakpoint
+  ) {
+    $('#left-column').removeClass().addClass('five wide column');
+    $('#right-column').removeClass().addClass('eleven wide column');
+    $('#left-column').show();
+    $('#right-column').show();
+  } else if ($(window).width() > twoColResizeBreakpoint) {
+    $('#left-column').removeClass().addClass('four wide column');
+    $('#right-column').removeClass().addClass('twelve wide column');
+    $('#left-column').show();
+    $('right-column').show();
+  }
 }

--- a/app/assets/styles/app.scss
+++ b/app/assets/styles/app.scss
@@ -8,7 +8,7 @@ nav {
   margin-bottom: 40px !important;
 }
 
-.nav-mobile-switch {
+.ui.menu .item.nav-mobile-switch {
   display: none;
 
   p {

--- a/app/assets/styles/app.scss
+++ b/app/assets/styles/app.scss
@@ -8,6 +8,14 @@ nav {
   margin-bottom: 40px !important;
 }
 
+.nav-mobile-switch {
+  display: none;
+
+  p {
+    display: inline-block;
+  }
+}
+
 // Desktop nav
 .ui.fixed.main.menu .right.menu > .item:last-of-type {
   border-right: 1px solid rgba(34, 36, 38, 0.0980392);

--- a/app/assets/styles/map.scss
+++ b/app/assets/styles/map.scss
@@ -196,6 +196,7 @@ $font-size: 14px;
 
 #map-footer {
   background-color: #EEEEEE;
+  display: none;
   overflow-y: auto;
   padding: 0.5em;
 

--- a/app/assets/styles/map.scss
+++ b/app/assets/styles/map.scss
@@ -19,6 +19,11 @@ $font-size: 14px;
   #right-column {
     padding: 0;
   }
+
+  &.grid-space {
+    padding-left: 2em;
+    padding-right: 2em;
+  }
 }
 
 #left-column-divider {

--- a/app/assets/styles/map.scss
+++ b/app/assets/styles/map.scss
@@ -1,4 +1,4 @@
-$accent-color: #2C9FA3;
+$accent-color: #000000; // change to specific color for non-generalized
 $font-choice: Roboto;
 $font-size: 14px;
 
@@ -20,9 +20,13 @@ $font-size: 14px;
     padding: 0;
   }
 
-  &.grid-space {
+  &.grid-space-large {
     padding-left: 2em;
     padding-right: 2em;
+  }
+
+  &.grid-space-small {
+    padding: 0;
   }
 }
 
@@ -137,7 +141,7 @@ $font-size: 14px;
   }
 
   .header {
-    display: inline-block;
+    display: block;
   }
 
   .ui.label {
@@ -188,6 +192,16 @@ $font-size: 14px;
 
 .more-info:hover {
   color: $accent-color;
+}
+
+#map-footer {
+  background-color: #EEEEEE;
+  overflow-y: auto;
+  padding: 0.5em;
+
+  #mobile-list-btn p {
+    display: inline-block;
+  }
 }
 
 /*************** RESOURCE VIEW SPECIFIC STYLES ****************/

--- a/app/static/styles/app.css
+++ b/app/static/styles/app.css
@@ -19,18 +19,27 @@ nav {
   margin-bottom: 40px !important;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\0000312}}
+@media -sass-debug-info{filename{}line{font-family:\0000311}}
+.nav-mobile-switch {
+  display: none;
+}
+@media -sass-debug-info{filename{}line{font-family:\0000314}}
+.nav-mobile-switch p {
+  display: inline-block;
+}
+
+@media -sass-debug-info{filename{}line{font-family:\0000320}}
 .ui.fixed.main.menu .right.menu > .item:last-of-type {
   border-right: 1px solid rgba(34, 36, 38, 0.09804);
 }
 
-@media -sass-debug-info{filename{}line{font-family:\0000318}}
+@media -sass-debug-info{filename{}line{font-family:\0000326}}
 nav .mobile.only.row .ui.vertical.menu {
   display: none;
   margin-top: 40px;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\0000325}}
+@media -sass-debug-info{filename{}line{font-family:\0000333}}
 .flashes > .ui.message:last-of-type {
   float: right;
   overflow: visible;
@@ -38,12 +47,12 @@ nav .mobile.only.row .ui.vertical.menu {
   z-index: 1000;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\0000333}}
+@media -sass-debug-info{filename{}line{font-family:\0000341}}
 table.selectable tr:hover {
   cursor: pointer !important;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\0000338}}
+@media -sass-debug-info{filename{}line{font-family:\0000346}}
 .ui.dropdown > .text {
   color: gray;
 }
@@ -68,18 +77,22 @@ table.selectable tr:hover {
   padding: 0;
 }
 @media -sass-debug-info{filename{}line{font-family:\0000323}}
-#map-list-grid.grid-space {
+#map-list-grid.grid-space-large {
   padding-left: 2em;
   padding-right: 2em;
 }
+@media -sass-debug-info{filename{}line{font-family:\0000328}}
+#map-list-grid.grid-space-small {
+  padding: 0;
+}
 
-@media -sass-debug-info{filename{}line{font-family:\0000329}}
+@media -sass-debug-info{filename{}line{font-family:\0000333}}
 #left-column-divider {
   margin-bottom: 0;
 }
 
 /*************** SEARCH STYLES ****************/
-@media -sass-debug-info{filename{}line{font-family:\0000335}}
+@media -sass-debug-info{filename{}line{font-family:\0000339}}
 #pac-input, #resources-input {
   background-color: #fff;
   float: left;
@@ -89,102 +102,102 @@ table.selectable tr:hover {
   text-overflow: ellipsis;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\0000344}}
+@media -sass-debug-info{filename{}line{font-family:\0000348}}
 #pac-input:focus, #resources-input:focus, #search-resources-req-options:focus {
-  border-color: #2C9FA3;
+  border-color: #000000;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\0000348}}
+@media -sass-debug-info{filename{}line{font-family:\0000352}}
 #location-search, #search-keyword, #resources-input {
   height: 40px;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\0000353}}
+@media -sass-debug-info{filename{}line{font-family:\0000357}}
 #search-user-resources {
-  background-color: #2C9FA3;
+  background-color: #000000;
   color: #fff;
   font-family: Roboto;
   font-weight: 400;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\0000361}}
+@media -sass-debug-info{filename{}line{font-family:\0000365}}
 #resource-search {
   background-color: #F8F8F8;
   box-shadow: none;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\0000366}}
+@media -sass-debug-info{filename{}line{font-family:\0000370}}
 .descriptor-group {
   font-family: Roboto;
   margin: 3px;
 }
-@media -sass-debug-info{filename{}line{font-family:\0000370}}
+@media -sass-debug-info{filename{}line{font-family:\0000374}}
 .descriptor-group h5 {
   font-family: Roboto;
   margin: 0 0 5px 0;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\0000376}}
+@media -sass-debug-info{filename{}line{font-family:\0000380}}
 .option-group, .option-group-advanced {
   margin-bottom: 10px;
   margin-top: 10px;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\0000381}}
+@media -sass-debug-info{filename{}line{font-family:\0000385}}
 .option-group-advanced {
   display: none;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\0000385}}
+@media -sass-debug-info{filename{}line{font-family:\0000389}}
 #advanced-filters-showhide {
-  color: #2C9FA3;
+  color: #000000;
   cursor: pointer;
   font-family: Roboto;
   margin-bottom: 0.5em;
   text-decoration: none;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\0000393}}
+@media -sass-debug-info{filename{}line{font-family:\0000397}}
 .checkbox-option {
   margin-right: 5px;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\0000397}}
+@media -sass-debug-info{filename{}line{font-family:\00003101}}
 .descriptor {
   display: block;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\00003101}}
+@media -sass-debug-info{filename{}line{font-family:\00003105}}
 #search-divider, #results-divider {
   color: #555;
   font-family: Roboto;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\00003106}}
+@media -sass-debug-info{filename{}line{font-family:\00003110}}
 #results-divider {
   margin-bottom: 0px;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\00003110}}
+@media -sass-debug-info{filename{}line{font-family:\00003114}}
 #search-keyword {
   margin: 0 0 5px 0;
 }
 
 /*************** LIST STYLES ****************/
-@media -sass-debug-info{filename{}line{font-family:\00003115}}
+@media -sass-debug-info{filename{}line{font-family:\00003119}}
 #list {
   height: 100%;
   margin-top: 0px;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\00003121}}
+@media -sass-debug-info{filename{}line{font-family:\00003125}}
 #list > .item.list-resource {
   cursor: pointer;
   margin: 0.5em;
   padding-bottom: 0.5em;
   padding-top: 0.5em;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003127}}
+@media -sass-debug-info{filename{}line{font-family:\00003131}}
 #list > .item.list-resource .sub.header {
   float: left;
   font-family: Roboto;
@@ -192,27 +205,27 @@ table.selectable tr:hover {
   margin-right: 15px;
   padding-right: 10px;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003134}}
+@media -sass-debug-info{filename{}line{font-family:\00003138}}
 #list > .item.list-resource .sub.header .ui.small.label {
   font-size: 14px;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003139}}
-#list > .item.list-resource .header {
-  display: inline-block;
-}
 @media -sass-debug-info{filename{}line{font-family:\00003143}}
+#list > .item.list-resource .header {
+  display: block;
+}
+@media -sass-debug-info{filename{}line{font-family:\00003147}}
 #list > .item.list-resource .ui.label {
   background-color: #DDDDDD;
   display: inline-block;
   margin-left: 0;
   margin-top: 0.5em;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003150}}
+@media -sass-debug-info{filename{}line{font-family:\00003154}}
 #list > .item.list-resource a, #list > .item.list-resource a:hover, #list > .item.list-resource a:active {
-  color: #2C9FA3;
+  color: #000000;
   font-family: Roboto;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003155}}
+@media -sass-debug-info{filename{}line{font-family:\00003159}}
 #list > .item.list-resource #resource-list-chevron {
   float: right;
   margin-top: 1.5em;
@@ -222,7 +235,7 @@ table.selectable tr:hover {
 }
 
 /*************** MAP STYLES ****************/
-@media -sass-debug-info{filename{}line{font-family:\00003166}}
+@media -sass-debug-info{filename{}line{font-family:\00003170}}
 #map {
   border: solid #CCCCCC;
   border-width: 1px 1px 1px 0;
@@ -230,31 +243,42 @@ table.selectable tr:hover {
   width: 100%;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\00003174}}
+@media -sass-debug-info{filename{}line{font-family:\00003178}}
 .marker-info {
   font-family: Roboto;
   padding: 0.25em;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\00003179}}
+@media -sass-debug-info{filename{}line{font-family:\00003183}}
 #marker-resource-name, #marker-resource-info {
   font-family: Roboto;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\00003183}}
+@media -sass-debug-info{filename{}line{font-family:\00003187}}
 .more-info {
-  color: #2C9FA3;
+  color: #000000;
   cursor: pointer;
   text-decoration: underline;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\00003189}}
+@media -sass-debug-info{filename{}line{font-family:\00003193}}
 .more-info:hover {
-  color: #2C9FA3;
+  color: #000000;
+}
+
+@media -sass-debug-info{filename{}line{font-family:\00003197}}
+#map-footer {
+  background-color: #EEEEEE;
+  overflow-y: auto;
+  padding: 0.5em;
+}
+@media -sass-debug-info{filename{}line{font-family:\00003202}}
+#map-footer #mobile-list-btn p {
+  display: inline-block;
 }
 
 /*************** RESOURCE VIEW SPECIFIC STYLES ****************/
-@media -sass-debug-info{filename{}line{font-family:\00003195}}
+@media -sass-debug-info{filename{}line{font-family:\00003209}}
 #resource-info {
   background-color: #F8F8F8;
   border: solid #CCCCCC;
@@ -264,51 +288,51 @@ table.selectable tr:hover {
   overflow: scroll;
   padding: 1.25em;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003205}}
+@media -sass-debug-info{filename{}line{font-family:\00003219}}
 #resource-info > .ui.header > .sub.header > .ui.label {
   margin-left: 0px;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003209}}
+@media -sass-debug-info{filename{}line{font-family:\00003223}}
 #resource-info a {
-  color: #2C9FA3;
+  color: #000000;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003213}}
+@media -sass-debug-info{filename{}line{font-family:\00003227}}
 #resource-info #resource-name {
   display: inline;
   font-size: 36px;
   padding-bottom: 1em;
   padding-top: 1em;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003220}}
+@media -sass-debug-info{filename{}line{font-family:\00003234}}
 #resource-info .successMessage {
   display: none;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003223}}
+@media -sass-debug-info{filename{}line{font-family:\00003237}}
 #resource-info .sub.header {
   font-size: 14px;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003227}}
+@media -sass-debug-info{filename{}line{font-family:\00003241}}
 #resource-info .ui.label {
   font-size: 14px;
   margin-top: 0.4em;
   margin-bottom: 1em;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003232}}
+@media -sass-debug-info{filename{}line{font-family:\00003246}}
 #resource-info .ui.header {
-  color: #2C9FA3;
+  color: #000000;
   font-family: Roboto;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\00003239}}
+@media -sass-debug-info{filename{}line{font-family:\00003253}}
 #back-button {
-  color: #2C9FA3;
+  color: #000000;
   display: inline-block;
   float: right;
   right: 1em;
   z-index: 2;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\00003247}}
+@media -sass-debug-info{filename{}line{font-family:\00003261}}
 #single-resource-map {
   height: 400px;
   width: 100%;

--- a/app/static/styles/app.css
+++ b/app/static/styles/app.css
@@ -20,11 +20,11 @@ nav {
 }
 
 @media -sass-debug-info{filename{}line{font-family:\0000311}}
-.nav-mobile-switch {
+.ui.menu .item.nav-mobile-switch {
   display: none;
 }
 @media -sass-debug-info{filename{}line{font-family:\0000314}}
-.nav-mobile-switch p {
+.ui.menu .item.nav-mobile-switch p {
   display: inline-block;
 }
 
@@ -269,16 +269,17 @@ table.selectable tr:hover {
 @media -sass-debug-info{filename{}line{font-family:\00003197}}
 #map-footer {
   background-color: #EEEEEE;
+  display: none;
   overflow-y: auto;
   padding: 0.5em;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003202}}
+@media -sass-debug-info{filename{}line{font-family:\00003203}}
 #map-footer #mobile-list-btn p {
   display: inline-block;
 }
 
 /*************** RESOURCE VIEW SPECIFIC STYLES ****************/
-@media -sass-debug-info{filename{}line{font-family:\00003209}}
+@media -sass-debug-info{filename{}line{font-family:\00003210}}
 #resource-info {
   background-color: #F8F8F8;
   border: solid #CCCCCC;
@@ -288,42 +289,42 @@ table.selectable tr:hover {
   overflow: scroll;
   padding: 1.25em;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003219}}
+@media -sass-debug-info{filename{}line{font-family:\00003220}}
 #resource-info > .ui.header > .sub.header > .ui.label {
   margin-left: 0px;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003223}}
+@media -sass-debug-info{filename{}line{font-family:\00003224}}
 #resource-info a {
   color: #000000;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003227}}
+@media -sass-debug-info{filename{}line{font-family:\00003228}}
 #resource-info #resource-name {
   display: inline;
   font-size: 36px;
   padding-bottom: 1em;
   padding-top: 1em;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003234}}
+@media -sass-debug-info{filename{}line{font-family:\00003235}}
 #resource-info .successMessage {
   display: none;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003237}}
+@media -sass-debug-info{filename{}line{font-family:\00003238}}
 #resource-info .sub.header {
   font-size: 14px;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003241}}
+@media -sass-debug-info{filename{}line{font-family:\00003242}}
 #resource-info .ui.label {
   font-size: 14px;
   margin-top: 0.4em;
   margin-bottom: 1em;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003246}}
+@media -sass-debug-info{filename{}line{font-family:\00003247}}
 #resource-info .ui.header {
   color: #000000;
   font-family: Roboto;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\00003253}}
+@media -sass-debug-info{filename{}line{font-family:\00003254}}
 #back-button {
   color: #000000;
   display: inline-block;
@@ -332,7 +333,7 @@ table.selectable tr:hover {
   z-index: 2;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\00003261}}
+@media -sass-debug-info{filename{}line{font-family:\00003262}}
 #single-resource-map {
   height: 400px;
   width: 100%;

--- a/app/static/styles/app.css
+++ b/app/static/styles/app.css
@@ -67,14 +67,19 @@ table.selectable tr:hover {
 #map-list-grid #right-column {
   padding: 0;
 }
+@media -sass-debug-info{filename{}line{font-family:\0000323}}
+#map-list-grid.grid-space {
+  padding-left: 2em;
+  padding-right: 2em;
+}
 
-@media -sass-debug-info{filename{}line{font-family:\0000324}}
+@media -sass-debug-info{filename{}line{font-family:\0000329}}
 #left-column-divider {
   margin-bottom: 0;
 }
 
 /*************** SEARCH STYLES ****************/
-@media -sass-debug-info{filename{}line{font-family:\0000330}}
+@media -sass-debug-info{filename{}line{font-family:\0000335}}
 #pac-input, #resources-input {
   background-color: #fff;
   float: left;
@@ -84,17 +89,17 @@ table.selectable tr:hover {
   text-overflow: ellipsis;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\0000339}}
+@media -sass-debug-info{filename{}line{font-family:\0000344}}
 #pac-input:focus, #resources-input:focus, #search-resources-req-options:focus {
   border-color: #2C9FA3;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\0000343}}
+@media -sass-debug-info{filename{}line{font-family:\0000348}}
 #location-search, #search-keyword, #resources-input {
   height: 40px;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\0000348}}
+@media -sass-debug-info{filename{}line{font-family:\0000353}}
 #search-user-resources {
   background-color: #2C9FA3;
   color: #fff;
@@ -102,35 +107,35 @@ table.selectable tr:hover {
   font-weight: 400;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\0000356}}
+@media -sass-debug-info{filename{}line{font-family:\0000361}}
 #resource-search {
   background-color: #F8F8F8;
   box-shadow: none;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\0000361}}
+@media -sass-debug-info{filename{}line{font-family:\0000366}}
 .descriptor-group {
   font-family: Roboto;
   margin: 3px;
 }
-@media -sass-debug-info{filename{}line{font-family:\0000365}}
+@media -sass-debug-info{filename{}line{font-family:\0000370}}
 .descriptor-group h5 {
   font-family: Roboto;
   margin: 0 0 5px 0;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\0000371}}
+@media -sass-debug-info{filename{}line{font-family:\0000376}}
 .option-group, .option-group-advanced {
   margin-bottom: 10px;
   margin-top: 10px;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\0000376}}
+@media -sass-debug-info{filename{}line{font-family:\0000381}}
 .option-group-advanced {
   display: none;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\0000380}}
+@media -sass-debug-info{filename{}line{font-family:\0000385}}
 #advanced-filters-showhide {
   color: #2C9FA3;
   cursor: pointer;
@@ -139,47 +144,47 @@ table.selectable tr:hover {
   text-decoration: none;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\0000388}}
+@media -sass-debug-info{filename{}line{font-family:\0000393}}
 .checkbox-option {
   margin-right: 5px;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\0000392}}
+@media -sass-debug-info{filename{}line{font-family:\0000397}}
 .descriptor {
   display: block;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\0000396}}
+@media -sass-debug-info{filename{}line{font-family:\00003101}}
 #search-divider, #results-divider {
   color: #555;
   font-family: Roboto;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\00003101}}
+@media -sass-debug-info{filename{}line{font-family:\00003106}}
 #results-divider {
   margin-bottom: 0px;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\00003105}}
+@media -sass-debug-info{filename{}line{font-family:\00003110}}
 #search-keyword {
   margin: 0 0 5px 0;
 }
 
 /*************** LIST STYLES ****************/
-@media -sass-debug-info{filename{}line{font-family:\00003110}}
+@media -sass-debug-info{filename{}line{font-family:\00003115}}
 #list {
   height: 100%;
   margin-top: 0px;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\00003116}}
+@media -sass-debug-info{filename{}line{font-family:\00003121}}
 #list > .item.list-resource {
   cursor: pointer;
   margin: 0.5em;
   padding-bottom: 0.5em;
   padding-top: 0.5em;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003122}}
+@media -sass-debug-info{filename{}line{font-family:\00003127}}
 #list > .item.list-resource .sub.header {
   float: left;
   font-family: Roboto;
@@ -187,27 +192,27 @@ table.selectable tr:hover {
   margin-right: 15px;
   padding-right: 10px;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003129}}
+@media -sass-debug-info{filename{}line{font-family:\00003134}}
 #list > .item.list-resource .sub.header .ui.small.label {
   font-size: 14px;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003134}}
+@media -sass-debug-info{filename{}line{font-family:\00003139}}
 #list > .item.list-resource .header {
   display: inline-block;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003138}}
+@media -sass-debug-info{filename{}line{font-family:\00003143}}
 #list > .item.list-resource .ui.label {
   background-color: #DDDDDD;
   display: inline-block;
   margin-left: 0;
   margin-top: 0.5em;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003145}}
+@media -sass-debug-info{filename{}line{font-family:\00003150}}
 #list > .item.list-resource a, #list > .item.list-resource a:hover, #list > .item.list-resource a:active {
   color: #2C9FA3;
   font-family: Roboto;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003150}}
+@media -sass-debug-info{filename{}line{font-family:\00003155}}
 #list > .item.list-resource #resource-list-chevron {
   float: right;
   margin-top: 1.5em;
@@ -217,7 +222,7 @@ table.selectable tr:hover {
 }
 
 /*************** MAP STYLES ****************/
-@media -sass-debug-info{filename{}line{font-family:\00003161}}
+@media -sass-debug-info{filename{}line{font-family:\00003166}}
 #map {
   border: solid #CCCCCC;
   border-width: 1px 1px 1px 0;
@@ -225,31 +230,31 @@ table.selectable tr:hover {
   width: 100%;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\00003169}}
+@media -sass-debug-info{filename{}line{font-family:\00003174}}
 .marker-info {
   font-family: Roboto;
   padding: 0.25em;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\00003174}}
+@media -sass-debug-info{filename{}line{font-family:\00003179}}
 #marker-resource-name, #marker-resource-info {
   font-family: Roboto;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\00003178}}
+@media -sass-debug-info{filename{}line{font-family:\00003183}}
 .more-info {
   color: #2C9FA3;
   cursor: pointer;
   text-decoration: underline;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\00003184}}
+@media -sass-debug-info{filename{}line{font-family:\00003189}}
 .more-info:hover {
   color: #2C9FA3;
 }
 
 /*************** RESOURCE VIEW SPECIFIC STYLES ****************/
-@media -sass-debug-info{filename{}line{font-family:\00003190}}
+@media -sass-debug-info{filename{}line{font-family:\00003195}}
 #resource-info {
   background-color: #F8F8F8;
   border: solid #CCCCCC;
@@ -259,42 +264,42 @@ table.selectable tr:hover {
   overflow: scroll;
   padding: 1.25em;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003200}}
+@media -sass-debug-info{filename{}line{font-family:\00003205}}
 #resource-info > .ui.header > .sub.header > .ui.label {
   margin-left: 0px;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003204}}
+@media -sass-debug-info{filename{}line{font-family:\00003209}}
 #resource-info a {
   color: #2C9FA3;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003208}}
+@media -sass-debug-info{filename{}line{font-family:\00003213}}
 #resource-info #resource-name {
   display: inline;
   font-size: 36px;
   padding-bottom: 1em;
   padding-top: 1em;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003215}}
+@media -sass-debug-info{filename{}line{font-family:\00003220}}
 #resource-info .successMessage {
   display: none;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003218}}
+@media -sass-debug-info{filename{}line{font-family:\00003223}}
 #resource-info .sub.header {
   font-size: 14px;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003222}}
+@media -sass-debug-info{filename{}line{font-family:\00003227}}
 #resource-info .ui.label {
   font-size: 14px;
   margin-top: 0.4em;
   margin-bottom: 1em;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003227}}
+@media -sass-debug-info{filename{}line{font-family:\00003232}}
 #resource-info .ui.header {
   color: #2C9FA3;
   font-family: Roboto;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\00003234}}
+@media -sass-debug-info{filename{}line{font-family:\00003239}}
 #back-button {
   color: #2C9FA3;
   display: inline-block;
@@ -303,7 +308,7 @@ table.selectable tr:hover {
   z-index: 2;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\00003242}}
+@media -sass-debug-info{filename{}line{font-family:\00003247}}
 #single-resource-map {
   height: 400px;
   width: 100%;

--- a/app/templates/macros/nav_macros.html
+++ b/app/templates/macros/nav_macros.html
@@ -14,6 +14,15 @@
     {% if current_user.is_authenticated() %}
         {% set href = url_for(current_user.role.index + '.index') %}
         <a class="item" href="{{ href }}">{{ current_user.role.name }} Dashboard</a>
+    {% else %}
+        <a class="item nav-mobile-switch" id="nav-to-map">
+          <i class="world icon"></i>
+          <p>Show Map</p>
+        </a>
+        <a class="item nav-mobile-switch" id="nav-to-list">
+          <i class="list icon"></i>
+          <p>Show List</p>
+        </a>
     {% endif %}
 {% endmacro %}
 

--- a/app/templates/main/index.html
+++ b/app/templates/main/index.html
@@ -119,13 +119,11 @@
 
     <div class="ui horizontal divider" id="results-divider">Results</div>
     <div id="list" class="ui middle aligned divided list"></div>
-
-    <!--<div class="ui divider" id="left-column-divider"></div>-->
-    <div class="ui middle aligned divided list" id="list"></div>
   </div>
 
   <div class="twelve wide column" id="right-column">
     <div id="map"></div>
+    <div id="map-footer"></div>
     <div id="resource-info"></div>
   </div>
 </div>
@@ -159,6 +157,12 @@
           <a class="more-info">More Information</a>
         </div>
     </h3>
+    {% raw %}{{#if responsive}}{% endraw %}
+      <a class="ui button item" id="mobile-list-btn">
+        <i class="list icon"></i>
+        <p>Show List</p>
+      </a>
+    {% raw %}{{/if}}{% endraw %}
   </div>
 </script>
 

--- a/app/templates/main/index.html
+++ b/app/templates/main/index.html
@@ -253,10 +253,12 @@
   $(document).ready(function(){
     // defined in map.js
     initMap();
+    makeResponsive();
     resizeMapListGrid();
 
     // Adjust height of map/list grid when resize browser to fit in screen
     $(window).resize(function() {
+      makeResponsive();
       resizeMapListGrid();
     });
 


### PR DESCRIPTION
For a window size x:
`x > twoColResizeBreakpoint` 
We have the size of the list and map columns be what it was originally

` singleColBreakpoint < x < twoColResizeBreakpoint`  
We still have two columns but make the list column a little larger to keep it from being squished

` singleColNoSpaceBreakpoint < x < singleColBreakpoint`  
- We switch to a single column where it will show only a list view or only a map view. We default to the list view
- We also add a nav element that allows switching between the list and the map view
- Clicking an element in the list hides the list and displays the map view
- In the map view, we have a map as well as a map footer that will replace the infowindow to display the marker info and a link back to the list view
- For a location search, we go to the map view to display the searched location

`x <  singleColNoSpaceBreakpoint `  
Everything stays the same as the above range (`singleColNoSpaceBreakpoint < x < singleColBreakpoint`)  except that now there is no white space around the grid (we use the whole screen width since for smaller screens we need to make the grid as big as possible)
