### PR TITLE
Fix bug of resource search view

### DIFF
--- a/app/assets/scripts/map.js
+++ b/app/assets/scripts/map.js
@@ -324,6 +324,7 @@ function resourceSearchRequest(endpoint) {
       markers[i].setMap(null);
     }
     markers = [];
+    $('#map').show();
     var resources = JSON.parse(resourcesString);
     if (resources.length != 0) {
       populateMarkers(resources);


### PR DESCRIPTION
Bug: When viewing a detailed resource view for a resource and then entering a new search, the map doesn't fully show the resulting markers and the marker info window is extremely squished

Now: we always show the map when we search for a resource, and before the bounds are set so that the map can be bounded to show all the matching resources