### PR TITLE
fixed so descriptor edit name does not display error on success

### DIFF
--- a/app/descriptor/views.py
+++ b/app/descriptor/views.py
@@ -93,7 +93,6 @@ def edit_name(desc_id):
     old_name = descriptor.name
     form = EditDescriptorNameForm()
     if form.validate_on_submit():
-        descriptor.name = form.name.data
         if Descriptor.query.filter(Descriptor.name == form.name.data).first() \
                 is not None:
             flash('Descriptor {} already exists.'.format(descriptor.name),
@@ -101,7 +100,8 @@ def edit_name(desc_id):
             return render_template('descriptor/manage_descriptor.html',
                                    desc=descriptor, form=form,
                                    is_option=is_option)
-
+            
+        descriptor.name = form.name.data
         db.session.add(descriptor)
         try:
             db.session.commit()

--- a/app/descriptor/views.py
+++ b/app/descriptor/views.py
@@ -95,12 +95,14 @@ def edit_name(desc_id):
     if form.validate_on_submit():
         if Descriptor.query.filter(Descriptor.name == form.name.data).first() \
                 is not None:
-            flash('Descriptor {} already exists.'.format(descriptor.name),
-                  'form-error')
+            if old_name == form.name.data:
+                flash('No change was made', 'form-error')
+            else:
+                flash('Descriptor {} already exists.'.format(form.name.data),
+                    'form-error')
             return render_template('descriptor/manage_descriptor.html',
                                    desc=descriptor, form=form,
                                    is_option=is_option)
-            
         descriptor.name = form.name.data
         db.session.add(descriptor)
         try:


### PR DESCRIPTION
Descriptor edit name functionality flashes fixed! previously showed errors on both success and failure, now only shows error on failure. 