### PR TITLE
Fix req desc csv setting

### DIFF
--- a/app/bulk_resource/views.py
+++ b/app/bulk_resource/views.py
@@ -431,6 +431,7 @@ def set_required_option_descriptor():
                         values=desc.values
                     )
                     db.session.add(req_opt_desc_const)
+                    db.session.commit()
                     return redirect(url_for('bulk_resource.validate_required_option_descriptor'))
 
             # If not in CSV, see if it is existing required option descriptor
@@ -445,6 +446,7 @@ def set_required_option_descriptor():
                         values=descriptor.values
                     )
                     db.session.add(req_opt_desc_const)
+                    db.session.commit()
                     return redirect(url_for('bulk_resource.validate_required_option_descriptor'))
             # If no descriptor found
             flash('Error: No required option descriptor. Please try again.', 'form-error')

--- a/app/bulk_resource/views.py
+++ b/app/bulk_resource/views.py
@@ -735,18 +735,19 @@ def save_csv():
         req_opt_desc = RequiredOptionDescriptor(descriptor_id=required_option_descriptor.id)
 
         # Add associations for the resources missing values for the required option descriptor
-        for name in req_opt_desc_const.missing_dict.keys():
-            resource = Resource.query.filter_by(
-                name=name
-            ).first()
-            if resource is not None:
-                for val in req_opt_desc_const.missing_dict[name]:
-                    new_association = OptionAssociation(
-                                        resource_id=resource.id,
-                                        descriptor_id=required_option_descriptor.id,
-                                        option=required_option_descriptor.values.index(val),
-                                        resource=resource, descriptor=required_option_descriptor)
-                    db.session.add(new_association)
+        if req_opt_desc_const.missing_dict:
+            for name in req_opt_desc_const.missing_dict.keys():
+                resource = Resource.query.filter_by(
+                    name=name
+                ).first()
+                if resource is not None:
+                    for val in req_opt_desc_const.missing_dict[name]:
+                        new_association = OptionAssociation(
+                                            resource_id=resource.id,
+                                            descriptor_id=required_option_descriptor.id,
+                                            option=required_option_descriptor.values.index(val),
+                                            resource=resource, descriptor=required_option_descriptor)
+                        db.session.add(new_association)
         db.session.delete(req_opt_desc_const)
         db.session.delete(csv_storage)
         db.session.add(req_opt_desc)

--- a/app/bulk_resource/views.py
+++ b/app/bulk_resource/views.py
@@ -597,10 +597,10 @@ def save_csv():
 
         RequiredOptionDescriptor.query.delete()
         if csv_storage.action == 'reset':
-            Descriptor.query.delete()
             OptionAssociation.query.delete()
-            Resource.query.delete()
             TextAssociation.query.delete()
+            Descriptor.query.delete()
+            Resource.query.delete()
 
         # Create/Update descriptors
         for desc in csv_storage.csv_descriptors:

--- a/app/models/resource.py
+++ b/app/models/resource.py
@@ -8,8 +8,8 @@ class OptionAssociation(db.Model):
     """
     __tablename__ = 'option_associations'
     id = db.Column(db.Integer, primary_key=True)
-    resource_id = db.Column(db.Integer, db.ForeignKey('resources.id'))
-    descriptor_id = db.Column(db.Integer, db.ForeignKey('descriptors.id'))
+    resource_id = db.Column(db.Integer, db.ForeignKey('resources.id', ondelete='CASCADE'))
+    descriptor_id = db.Column(db.Integer, db.ForeignKey('descriptors.id', ondelete='CASCADE'))
     option = db.Column(db.Integer)
     resource = db.relationship('Resource',
                                back_populates='option_descriptors')
@@ -28,8 +28,8 @@ class TextAssociation(db.Model):
     """
     __tablename__ = 'text_associations'
     id = db.Column(db.Integer, primary_key=True)
-    resource_id = db.Column(db.Integer, db.ForeignKey('resources.id'))
-    descriptor_id = db.Column(db.Integer, db.ForeignKey('descriptors.id'))
+    resource_id = db.Column(db.Integer, db.ForeignKey('resources.id', ondelete='CASCADE'))
+    descriptor_id = db.Column(db.Integer, db.ForeignKey('descriptors.id', ondelete='CASCADE'))
     text = db.Column(db.Text)
     resource = db.relationship('Resource', back_populates='text_descriptors')
     descriptor = db.relationship('Descriptor', back_populates='text_resources')
@@ -51,12 +51,12 @@ class Descriptor(db.Model):
     text_resources = db.relationship(
         'TextAssociation',
         back_populates='descriptor',
-        cascade='save-update, merge, delete, delete-orphan'
+        cascade='all, save-update, merge, delete, delete-orphan'
     )
     option_resources = db.relationship(
         'OptionAssociation',
         back_populates='descriptor',
-        cascade='save-update, merge, delete, delete-orphan'
+        cascade='all, save-update, merge, delete, delete-orphan'
     )
 
     def __repr__(self):


### PR DESCRIPTION
- Commit req desc constructor model changes: creates errors if don't on Heroku
- Change order of deletion because of foreign key reference errors on Heroku
- Add foreign key ondelete cascade to enforce deletion of child when parent deleted
- Check if the dictionary of resources missing the required option descriptor value is not empty