### PR TITLE
Fix CSV creation and displaying of option descriptors

### DIFF
--- a/app/assets/scripts/map.js
+++ b/app/assets/scripts/map.js
@@ -79,11 +79,15 @@ function markerListener(marker, event) {
 function displayPhoneNumbers(descriptors) {
   var PHONE_NUMBER_LENGTH = 12;
   for (desc of descriptors) {
-    var updated = desc.value.replace(/(\d\d\d-\d\d\d-\d\d\d\d)/g,
-      function replacePhoneNum(num) {
-        return "<a href=\"tel:+1-" + num +  "\">" + num + "</a>";
-    });
-    $('#descriptor-value-'+desc.key).html(updated);
+    // skip option descriptors
+    if (desc.value.replace) {
+      var updated = desc.value.replace(/(\d\d\d-\d\d\d-\d\d\d\d)/g,
+        function replacePhoneNum(num) {
+          return "<a href=\"tel:+1-" + num + "\">" + num + "</a>";
+        }
+      );
+      $('#descriptor-value-'+desc.key).html(updated);
+    }
   }
 }
 
@@ -100,9 +104,16 @@ function displayDetailedResourceView(marker) {
     var associationObject = JSON.parse(associations);
     var descriptors = [];
     for (var key in associationObject) {
+      value = associationObject[key];
+
+      // Combine multiple option descriptor values
+      if (Array.isArray(associationObject[key])) {
+        value = Object.values(value).join(', ');
+      }
+
       var descriptor = {
         key: key,
-        value: associationObject[key],
+        value: value
       };
       descriptors.push(descriptor);
     }

--- a/app/bulk_resource/views.py
+++ b/app/bulk_resource/views.py
@@ -687,6 +687,7 @@ def save_csv():
                         keyword = 'option'
                         curr_opts = []
                         for s in row.data[key].split(';'):
+                            s = s.strip()
                             if s in values:
                                 curr_opts.append(values.index(s))
                         # see if same descriptor already exists

--- a/app/descriptor/views.py
+++ b/app/descriptor/views.py
@@ -407,10 +407,10 @@ def review_required_option_descriptor():
                                             resource=resource,
                                             descriptor=descriptor)
                         db.session.add(new_association)
-                RequiredOptionDescriptor.query.delete()
-                req_opt_desc = RequiredOptionDescriptor(descriptor_id=descriptor.id)
-                db.session.add(req_opt_desc)
-                db.session.commit()
+            RequiredOptionDescriptor.query.delete()
+            req_opt_desc = RequiredOptionDescriptor(descriptor_id=descriptor.id)
+            db.session.add(req_opt_desc)
+            db.session.commit()
             return redirect(url_for('descriptor.index'))
     for j, r_name in enumerate(missing_resources):
         form.resources.append_entry()

--- a/app/main/views.py
+++ b/app/main/views.py
@@ -111,7 +111,16 @@ def get_associations(resource_id):
     for td in resource.text_descriptors:
         associations[td.descriptor.name] = td.text
     for od in resource.option_descriptors:
-        associations[od.descriptor.name] = od.descriptor.values[od.option]
+        val = od.descriptor.values[od.option]
+        values = set()
+        # multiple option association values
+        if associations.get(od.descriptor.name):
+            curr = associations.get(od.descriptor.name)
+            curr.append(val)
+            values = set(curr)
+        else:
+            values.add(val)
+        associations[od.descriptor.name] = list(values)
     return json.dumps(associations)
 
 @main.route('/about')


### PR DESCRIPTION
CSV:
- If a resource had multiple option values for an option descriptor in the CSV, we weren't accepting values that could have a space between the delimiter `;`
now we accept `blue; green; red` (note space between values)

Displaying:
- When sending resource descriptor values to the frontend to display, we weren't accounting for multiple (only sent the first option value), now we send a list for the option descriptor values
- When displaying multiple option values, we delimit them by a space and comma:
![screen shot 2017-01-24 at 12 29 04 am](https://cloud.githubusercontent.com/assets/5404536/22235214/26c4b8f2-e1cc-11e6-936b-66a0b686476a.png)
- Don't do phone number parsing on this list of option descriptors (only for text descriptors)

Required Option Descriptor:
- Was not changing properly since functionality to delete existing and switch to new was over-indented 