### PR TITLE
Make resource name search case insensitive

### DIFF
--- a/app/main/views.py
+++ b/app/main/views.py
@@ -46,7 +46,8 @@ def search_resources():
     req_options = request.args.getlist('reqoption')
     if req_options is None:
         req_options = []
-    resource_pool = Resource.query.filter(Resource.name.contains(name)).all()
+    # case insensitive search
+    resource_pool = Resource.query.filter(Resource.name.ilike('%{}%'.format(name))).all()
     req_opt_desc = RequiredOptionDescriptor.query.all()[0]
     req_opt_desc = Descriptor.query.filter_by(
         id=req_opt_desc.descriptor_id


### PR DESCRIPTION
Worked before without this on local because SQLite but on Heroku with Postgresql the original search was case sensitive