### PR TITLE
Removing psycopg2 from requirements.

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -27,7 +27,6 @@ Mako==1.0.1
 MarkupSafe==0.23
 mccabe==0.4.0
 pep8==1.7.0
-psycopg2==2.6.1
 pyflakes==1.0.0
 pytz==2016.3
 ratelim==0.1.6


### PR DESCRIPTION
As far as I tested and run the application locally, it doesn't need to have the postgresql library installed. It uses sqlite.

Also, if this is kept in the requirements, the user has to install the development library for its operating system. I think the if it can use sqlite for development, this requirement can be removed safely.