### PR TITLE
Fix documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,23 @@ Mac (using [homebrew](http://brew.sh/)):
 $ brew install redis
 ```
 
-Linux:
+Linux (Fedora)
+
+```
+$ sudo dnf install redis
+```
+
+Linux (Debian/Ubuntu):
 
 ```
 $ sudo apt-get install redis-server
+```
+
+Using Redis docker:
+
+```
+$ docker pull redis:latest
+$ docker run -d -p 6379:6379 --name maps4all-redis redis:latest
 ```
 
 ##### Create the database

--- a/README.md
+++ b/README.md
@@ -65,30 +65,31 @@ You need to install [Foreman](https://ddollar.github.io/foreman/) and [Redis](ht
 $ gem install foreman
 ```
 
-Mac (using [homebrew](http://brew.sh/)):
+For Mac (using [homebrew](http://brew.sh/)):
 
 ```
 $ brew install redis
 ```
 
-Linux (Fedora)
+For Linux (Fedora)
 
 ```
 $ sudo dnf install redis
 ```
 
-Linux (Debian/Ubuntu):
+For Linux (Debian/Ubuntu):
 
 ```
 $ sudo apt-get install redis-server
 ```
 
-Using Redis docker:
+If you don't want to install redis locally, you can use Redis container with docker
 
 ```
 $ docker pull redis:latest
 $ docker run -d -p 6379:6379 --name maps4all-redis redis:latest
 ```
+
 
 ##### Create the database
 
@@ -113,6 +114,20 @@ $ python manage.py add_fake_data
 ```
 $ source env/bin/activate
 $ foreman start -f Local
+```
+
+**Note**: if you are using Redis container with docker, you can ignore the error that `foreman` will display when you run the `foreman` command above. `foreman` will try to start the redis-server locally and it will not find the `redis-server` command. This is fine as long as you followed the instructions above to run Redis in a container. The error should look like this
+
+```
+$ foreman start -f Local
+10:22:56 redis.1  | unknown command: redis-server
+10:22:56 web.1    | started with pid 14409
+10:22:56 worker.1 | started with pid 14410
+10:22:57 worker.1 | 10:22:57 RQ worker u'rq:worker:dev.14410' started, version 0.5.6
+10:22:57 worker.1 | 10:22:57 
+10:22:57 worker.1 | 10:22:57 *** Listening on default...
+10:22:57 web.1    |  * Running on http://127.0.0.1:5000/ (Press CTRL+C to quit)
+10:22:57 web.1    |  * Restarting with stat
 ```
 
 ## Project Structure

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ $ source env/bin/activate
 $ foreman start -f Local
 ```
 
-**Note**: if you are using Redis container with docker, you can ignore the error that `foreman` will display when you run the `foreman` command above. `foreman` will try to start the redis-server locally and it will not find the `redis-server` command. This is fine as long as you followed the instructions above to run Redis in a container. The error should look like this
+**Note**: if you are using Redis container with docker, you can ignore the error that `foreman` will display when you run the `foreman` command above. `foreman` will try to start the redis-server locally and it will not find the `redis-server` command. This is fine as long as you followed the [instructions above](#other-dependencies-for-running-locally) to run Redis in a container. The error should look like this
 
 ```
 $ foreman start -f Local


### PR DESCRIPTION
I think it won't hurt if we add instructions on

* How to install Redis on Fedora
* How to use Redis in a container for docker instead of installing locally.

I personally like to avoid installing a service/server app in my development environment and use container as much as possible, so I keep environment as clean as I can.