### PR TITLE
make contact editor name and page name match

### DIFF
--- a/app/contact/views.py
+++ b/app/contact/views.py
@@ -20,7 +20,7 @@ def index():
     editable_html_obj = EditableHTML.get_editable_html('contact')
 
     if editable_html_obj is False:
-        edit = EditableHTML(editor_name='contact', page_name='Overview', value='')
+        edit = EditableHTML(editor_name='contact', page_name='Contact', value='')
         db.session.add(edit)
         db.session.commit()
         editable_html_obj = edit


### PR DESCRIPTION
page_name field is unique, and this was a copy paste that never got changed, so it was causing the integrity error