### PR TITLE
Remove release command from procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,3 @@
 web: gunicorn manage:app
 worker: python -u manage.py run_worker
 init: python manage.py recreate_db && python manage.py setup_dev && python manage.py add_fake_data
-release: python manage.py db upgrade


### PR DESCRIPTION
This will stop the issue of new instances not deploying, will open a PR with the new fix ASAP (I think we just need to check whether the dtype & hyperlink table already exist in the db before attempting to perform the migration)